### PR TITLE
 QE1095: Update esxi network type to hybrid-bonded for private link

### DIFF
--- a/metal-gateway.tf
+++ b/metal-gateway.tf
@@ -3,7 +3,7 @@ resource "equinix_metal_device_network_type" "this" {
   count = var.create_metal_gateway ? 1 : 0
 
   device_id = equinix_metal_device.this.id
-  type      = "hybrid"
+  type      = "hybrid-bonded"
 
   depends_on = [equinix_metal_device.this]
 }


### PR DESCRIPTION
 Update esxi network type to hybrid-bonded for private link